### PR TITLE
Integrate MLB schedule API

### DIFF
--- a/betting-agent/README.md
+++ b/betting-agent/README.md
@@ -34,3 +34,13 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## MLB Data Integration
+
+The project includes a basic API route that proxies data from the public [MLB Stats API](https://statsapi.mlb.com/). You can request the current schedule via `/api/mlb/schedule?date=YYYY-MM-DD` and display the games inside the app.
+
+## Disclaimers
+
+- Game schedules and stats come from third‑party sources and may be incomplete or inaccurate.
+- AI generated analyses are for entertainment purposes only and do not constitute betting advice.
+- Use the application responsibly and at your own risk.

--- a/betting-agent/src/app/api/mlb/schedule/route.js
+++ b/betting-agent/src/app/api/mlb/schedule/route.js
@@ -1,0 +1,29 @@
+export async function GET(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const date = searchParams.get('date') || new Date().toISOString().split('T')[0];
+
+    const apiUrl = `https://statsapi.mlb.com/api/v1/schedule?sportId=1&date=${date}`;
+    const res = await fetch(apiUrl);
+    if (!res.ok) {
+      return new Response(
+        JSON.stringify({ error: 'Failed to fetch MLB schedule' }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const data = await res.json();
+    const games = data.dates?.flatMap(d => d.games) || [];
+
+    return new Response(
+      JSON.stringify({ games }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('Error fetching MLB schedule:', error);
+    return new Response(
+      JSON.stringify({ error: 'Error fetching MLB schedule' }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/betting-agent/src/app/events/page.js
+++ b/betting-agent/src/app/events/page.js
@@ -1,13 +1,17 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { fetchMLBSchedule } from '@/utils/api';
 
 export default function Events() {
   // Sport filter state
   const [selectedSport, setSelectedSport] = useState('all');
-  
+
+  // Events state
+  const [events, setEvents] = useState([]);
+
   // Sample events data - in a real app, this would come from an API
-  const events = [
+  const defaultEvents = [
     {
       id: 1,
       sport: 'football',
@@ -121,6 +125,38 @@ export default function Events() {
       }
     },
   ];
+
+
+
+  // Load initial events and refresh when sport changes
+  useEffect(() => {
+    async function loadEvents() {
+      if (selectedSport === 'baseball') {
+        try {
+          const games = await fetchMLBSchedule();
+          const mlbEvents = games.map((g) => ({
+            id: g.gamePk,
+            sport: 'baseball',
+            sportName: 'Baseball',
+            league: g.league?.name || 'MLB',
+            teams: `${g.teams.away.team.name} vs ${g.teams.home.team.name}`,
+            date: g.gameDate,
+            venue: g.venue?.name || '',
+            odds: {}
+          }));
+          setEvents(mlbEvents);
+        } catch (err) {
+          console.error('Failed to load MLB schedule', err);
+          setEvents([]);
+        }
+      } else {
+        setEvents(defaultEvents);
+      }
+    }
+
+    loadEvents();
+  }, [selectedSport]);
+  
 
   // Filter events by sport
   const filteredEvents = selectedSport === 'all' 

--- a/betting-agent/src/utils/api.js
+++ b/betting-agent/src/utils/api.js
@@ -128,3 +128,23 @@ export const updateAnalysisOutcome = (analysisId, outcome, roi) => {
   }
   return false;
 };
+
+/**
+ * Fetch MLB schedule data from the server
+ * @param {string} [date] - Date in YYYY-MM-DD format
+ * @returns {Promise<Array>} Array of game objects
+ */
+export const fetchMLBSchedule = async (date) => {
+  try {
+    const query = date ? `?date=${date}` : '';
+    const res = await fetch(`/api/mlb/schedule${query}`);
+    if (!res.ok) {
+      throw new Error('Failed to fetch MLB schedule');
+    }
+    const data = await res.json();
+    return data.games || [];
+  } catch (error) {
+    console.error('Error fetching MLB schedule:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- add Next.js API route for MLB schedule data
- fetch MLB games in events page when baseball is selected
- expose helper `fetchMLBSchedule` in api utils
- document MLB integration and add disclaimers in README

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7117b84c8330ac49ebecd9c2e332