### PR TITLE
Remove placeholder data from UI

### DIFF
--- a/betting-agent/src/app/events/page.js
+++ b/betting-agent/src/app/events/page.js
@@ -10,128 +10,13 @@ export default function Events() {
   // Events state
   const [events, setEvents] = useState([]);
 
-  // Sample events data - in a real app, this would come from an API
-  const defaultEvents = [
-    {
-      id: 1,
-      sport: 'football',
-      sportName: 'Football',
-      league: 'NFL',
-      teams: 'Kansas City Chiefs vs San Francisco 49ers',
-      date: '2025-06-15T20:00:00',
-      venue: 'Arrowhead Stadium',
-      odds: {
-        favorite: 'Chiefs -3.5',
-        underdog: '49ers +3.5',
-        over_under: 49.5
-      }
-    },
-    {
-      id: 2,
-      sport: 'basketball',
-      sportName: 'Basketball',
-      league: 'NBA',
-      teams: 'Boston Celtics vs Los Angeles Lakers',
-      date: '2025-06-10T19:30:00',
-      venue: 'TD Garden',
-      odds: {
-        favorite: 'Celtics -5.5',
-        underdog: 'Lakers +5.5',
-        over_under: 219.5
-      }
-    },
-    {
-      id: 3,
-      sport: 'baseball',
-      sportName: 'Baseball',
-      league: 'MLB',
-      teams: 'New York Yankees vs Boston Red Sox',
-      date: '2025-06-07T13:00:00',
-      venue: 'Yankee Stadium',
-      odds: {
-        favorite: 'Yankees -1.5',
-        underdog: 'Red Sox +1.5',
-        over_under: 8.5
-      }
-    },
-    {
-      id: 4,
-      sport: 'soccer',
-      sportName: 'Soccer',
-      league: 'Premier League',
-      teams: 'Manchester City vs Liverpool',
-      date: '2025-06-12T15:00:00',
-      venue: 'Etihad Stadium',
-      odds: {
-        favorite: 'Man City -0.5',
-        underdog: 'Liverpool +0.5',
-        over_under: 2.5
-      }
-    },
-    {
-      id: 5,
-      sport: 'hockey',
-      sportName: 'Hockey',
-      league: 'NHL',
-      teams: 'Toronto Maple Leafs vs Montreal Canadiens',
-      date: '2025-06-08T19:00:00',
-      venue: 'Scotiabank Arena',
-      odds: {
-        favorite: 'Maple Leafs -1.5',
-        underdog: 'Canadiens +1.5',
-        over_under: 5.5
-      }
-    },
-    {
-      id: 6,
-      sport: 'golf',
-      sportName: 'Golf',
-      league: 'PGA Tour',
-      teams: 'The Masters Tournament',
-      date: '2025-06-20T08:00:00',
-      venue: 'Augusta National Golf Club',
-      odds: {
-        favorite: 'Scottie Scheffler +800',
-        underdog: 'Jordan Spieth +2000',
-        over_under: null
-      }
-    },
-    {
-      id: 7,
-      sport: 'mma',
-      sportName: 'MMA',
-      league: 'UFC',
-      teams: 'Jon Jones vs Francis Ngannou',
-      date: '2025-06-17T22:00:00',
-      venue: 'T-Mobile Arena',
-      odds: {
-        favorite: 'Jones -150',
-        underdog: 'Ngannou +130',
-        over_under: '3.5 rounds'
-      }
-    },
-    {
-      id: 8,
-      sport: 'tennis',
-      sportName: 'Tennis',
-      league: 'Grand Slam',
-      teams: 'Carlos Alcaraz vs Novak Djokovic',
-      date: '2025-06-25T14:00:00',
-      venue: 'Wimbledon',
-      odds: {
-        favorite: 'Alcaraz -125',
-        underdog: 'Djokovic +105',
-        over_under: '38.5 games'
-      }
-    },
-  ];
 
 
 
   // Load initial events and refresh when sport changes
   useEffect(() => {
     async function loadEvents() {
-      if (selectedSport === 'baseball') {
+      if (selectedSport === 'baseball' || selectedSport === 'all') {
         try {
           const games = await fetchMLBSchedule();
           const mlbEvents = games.map((g) => ({
@@ -150,7 +35,7 @@ export default function Events() {
           setEvents([]);
         }
       } else {
-        setEvents(defaultEvents);
+        setEvents([]);
       }
     }
 

--- a/betting-agent/src/app/history/page.js
+++ b/betting-agent/src/app/history/page.js
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
+import { getBettingHistory } from '@/utils/api';
 
 export default function History() {
   const [filter, setFilter] = useState('all');
@@ -10,108 +11,9 @@ export default function History() {
   
   // Load saved analyses on component mount
   useEffect(() => {
-    // In a real app, this would come from a database
-    // Here we'll simulate getting it from localStorage
-    const timer = setTimeout(() => {
-      const mockAnalyses = [
-        {
-          id: '12345',
-          date: '2025-05-28',
-          event: {
-            sport: 'Football',
-            league: 'NFL',
-            teams: 'Dallas Cowboys vs Philadelphia Eagles',
-          },
-          recommendation: 'Cowboys +3.5',
-          confidence: 0.84,
-          outcome: 'win',
-          roi: '+110',
-        },
-        {
-          id: '12346',
-          date: '2025-05-26',
-          event: {
-            sport: 'Basketball',
-            league: 'NBA',
-            teams: 'Los Angeles Lakers vs Golden State Warriors',
-          },
-          recommendation: 'Over 219.5',
-          confidence: 0.65,
-          outcome: 'loss',
-          roi: '-110',
-        },
-        {
-          id: '12347',
-          date: '2025-05-24',
-          event: {
-            sport: 'Baseball',
-            league: 'MLB',
-            teams: 'New York Yankees vs Boston Red Sox',
-          },
-          recommendation: 'Yankees ML',
-          confidence: 0.78,
-          outcome: 'win',
-          roi: '-105',
-        },
-        {
-          id: '12348',
-          date: '2025-05-22',
-          event: {
-            sport: 'Soccer',
-            league: 'Premier League',
-            teams: 'Arsenal vs Manchester United',
-          },
-          recommendation: 'Draw',
-          confidence: 0.52,
-          outcome: 'pending',
-          roi: '+240',
-        },
-        {
-          id: '12349',
-          date: '2025-05-20',
-          event: {
-            sport: 'Hockey',
-            league: 'NHL',
-            teams: 'Toronto Maple Leafs vs Montreal Canadiens',
-          },
-          recommendation: 'Under 5.5',
-          confidence: 0.71,
-          outcome: 'win',
-          roi: '-115',
-        },
-        {
-          id: '12350',
-          date: '2025-05-18',
-          event: {
-            sport: 'Football',
-            league: 'NFL',
-            teams: 'Buffalo Bills vs Miami Dolphins',
-          },
-          recommendation: 'Bills -2.5',
-          confidence: 0.68,
-          outcome: 'push',
-          roi: 'Even',
-        },
-        {
-          id: '12351',
-          date: '2025-05-16',
-          event: {
-            sport: 'Basketball',
-            league: 'NBA',
-            teams: 'Boston Celtics vs Milwaukee Bucks',
-          },
-          recommendation: 'Celtics -4.5',
-          confidence: 0.75,
-          outcome: 'loss',
-          roi: '-110',
-        },
-      ];
-      
-      setAnalyses(mockAnalyses);
-      setLoading(false);
-    }, 1000);
-    
-    return () => clearTimeout(timer);
+    const history = getBettingHistory();
+    setAnalyses(history);
+    setLoading(false);
   }, []);
   
   // Filter and sort analyses

--- a/betting-agent/src/components/RecentAnalyses.js
+++ b/betting-agent/src/components/RecentAnalyses.js
@@ -1,41 +1,14 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { getBettingHistory } from '@/utils/api';
 
 export function RecentAnalyses() {
-  // Sample data - in a real app, this would come from a database
-  const analyses = [
-    {
-      id: 1,
-      event: 'Dallas Cowboys vs Philadelphia Eagles',
-      date: '2025-05-28',
-      recommendation: 'Cowboys +3.5',
-      confidence: 'high',
-      result: 'win'
-    },
-    {
-      id: 2,
-      event: 'Los Angeles Lakers vs Golden State Warriors',
-      date: '2025-05-26',
-      recommendation: 'Over 219.5',
-      confidence: 'medium',
-      result: 'loss'
-    },
-    {
-      id: 3,
-      event: 'New York Yankees vs Boston Red Sox',
-      date: '2025-05-24',
-      recommendation: 'Yankees ML',
-      confidence: 'high',
-      result: 'win'
-    },
-    {
-      id: 4,
-      event: 'Arsenal vs Manchester United',
-      date: '2025-05-22',
-      recommendation: 'Draw',
-      confidence: 'low',
-      result: 'pending'
-    },
-  ];
+  const [analyses, setAnalyses] = useState([]);
+
+  useEffect(() => {
+    const history = getBettingHistory();
+    const sorted = [...history].sort((a, b) => new Date(b.date) - new Date(a.date));
+    setAnalyses(sorted.slice(0, 4));
+  }, []);
 
   const getConfidenceBadge = (confidence) => {
     switch(confidence) {


### PR DESCRIPTION
## Summary
- fetch betting stats from local storage
- load real MLB events instead of dummy data
- show real recent analyses from history
- remove hardcoded event list
- use stored history for the history page

## Testing
- `npm install`
- `npm run lint` *(fails: Do not use an `<a>` element to navigate to `/`)*

------
https://chatgpt.com/codex/tasks/task_e_683f7403744883308bfe24c6f2d77176